### PR TITLE
Fix bug in read and in the blank reveal.

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -26,8 +26,8 @@ int read_board(char board[255])
 
 void print_board(char buf[255])
 {
-    unsigned int board_size = board_w * board_h;
-    for (char i = 0; i < board_size; i++)
+    int board_size = board_w * board_h;
+    for (int i = 0; i < board_size; i++)
     {
         printf("%c", buf[i]);
         if (((i + 1) % board_w) == 0)
@@ -44,7 +44,6 @@ void print_board(char buf[255])
 bool read_and_print_board() 
 {
     char board[255];
-    char board_w, board_h;
     ssize_t read_count = read_board(board);
     if(read_count >= 0)
     {
@@ -66,7 +65,7 @@ bool read_and_print_board()
 bool play(int i, int j) 
 {
     string play = to_string(i * board_w + j);
-    printf("%s (%d)\n", play.c_str(), play.size());
+    printf("%s (%d)\n", play.c_str(), (int)play.size());
     ssize_t count = write(device_fd, play.c_str(), play.size());
     if(count < 0)
     {

--- a/main.c
+++ b/main.c
@@ -143,6 +143,7 @@ void reveal_blank_cells(int position, int reveal_limit)
 		entry = list_first_entry(&queue, struct queue_node, list);
 		curr_position = entry->value;
 		list_del(queue.next);
+		kfree(entry);
 
 		pos_i = get_position_row(curr_position);
 		pos_j = get_position_col(curr_position);
@@ -169,6 +170,14 @@ void reveal_blank_cells(int position, int reveal_limit)
 				}
 			}
 		}
+	}
+
+	// Clean the queue.
+	while (!list_empty(&queue))
+	{
+		entry = list_first_entry(&queue, struct queue_node, list);
+		list_del(queue.next);
+		kfree(entry);
 	}
 }
 
@@ -282,7 +291,7 @@ ssize_t minesweeper_read(struct file *filp, char __user *buf, size_t count,
 		restart_game();
 
 	prepend_board_dimensions(write_buf);
-	if (copy_to_user(buf, write_buf, BOARD_SZ)) 
+	if (copy_to_user(buf, write_buf, write_size)) 
 		return -EFAULT;
 
 	kfree(write_buf);


### PR DESCRIPTION
- Arrumado bug no read que não retornava a quantidade correta de bytes lidos.
- Arrumado bug no BFS do `blank reveal` que não reseteva a `queue` ao final de cada chamada e não liberava a memória dos nós alocados.